### PR TITLE
Link to stable Elixir Docs

### DIFF
--- a/docs/secure_coding_and_deployment_hardening/resources.md
+++ b/docs/secure_coding_and_deployment_hardening/resources.md
@@ -18,9 +18,9 @@ Static analysis:
 
 ### Anti-patterns in Elixir
 
-The Elixir documentation includes a section on [https://hexdocs.pm/elixir/main/what-anti-patterns.html](anti-patterns): common mistakes or indicators of potential problems in code. The unintended behaviours caused by such mistakes or problems may lead to vulnerabilities. Getting familiar with these anti-patterns and learning to avoid them can help produce cleaner code, fewer bugs, fewer surpises and therefore fewer vulnerabilities.
+The Elixir documentation includes a section on [https://hexdocs.pm/elixir/what-anti-patterns.html](anti-patterns): common mistakes or indicators of potential problems in code. The unintended behaviours caused by such mistakes or problems may lead to vulnerabilities. Getting familiar with these anti-patterns and learning to avoid them can help produce cleaner code, fewer bugs, fewer surpises and therefore fewer vulnerabilities.
 
-For instance, the [https://hexdocs.pm/elixir/main/code-anti-patterns.html#non-assertive-truthiness](Non-assertive truthiness) anti-pattern can lead to logic errors in authentication or authorization checks.
+For instance, the [https://hexdocs.pm/elixir/code-anti-patterns.html#non-assertive-truthiness](Non-assertive truthiness) anti-pattern can lead to logic errors in authentication or authorization checks.
 
 ### Other documentation
 


### PR DESCRIPTION
We can link to the stable documentation instead of `main` since elixir 1.16 was released.