### PR TITLE
Set `crl_check` to `best_effort`

### DIFF
--- a/docs/secure_coding_and_deployment_hardening/ssl.md
+++ b/docs/secure_coding_and_deployment_hardening/ssl.md
@@ -60,7 +60,7 @@ Make sure to test the selected options against test endpoints, such as those pro
 
 ## Revocation check
 
-One scenario that’s not handled by the above examples is certificate revocation: no revocation check is performed, and therefore a revoked but otherwise valid certificate would be accepted. It is possible to check certificates against the CA’s Certificate Revocation List (CRL) by setting the `crl_check` option to true. This also requires the `crl_cache` to be configured:
+One scenario that’s not handled by the above examples is certificate revocation: no revocation check is performed, and therefore a revoked but otherwise valid certificate would be accepted. It is possible to check certificates against the CA’s Certificate Revocation List (CRL) by setting the `crl_check` option to `best_effort`. This also requires the `crl_cache` to be configured:
 
 ```erlang
 %% Erlang
@@ -71,7 +71,7 @@ ssl:connect("revoked.badssl.com", 443, [
     {customize_hostname_check, [
         {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
     ]},
-    {crl_check, true},
+    {crl_check, best_effort},
     {crl_cache, {ssl_crl_cache, {internal, [{http, 1000}]}}}
 ]).
 ```
@@ -85,10 +85,12 @@ ssl:connect("revoked.badssl.com", 443, [
   customize_hostname_check: [
     match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
   ],
-  crl_check: true,
+  crl_check: :best_effort,
   crl_cache: {:ssl_crl_cache, {:internal, [http: 1000]}}
 )
 ```
+
+The stricter `true` can be used instead of `best_effort`: in this case validation will fail if CRL is missing, which can happen if the certificate has no CRL or exclusively uses OCSP.
 
 However, please note that the `ssl_crl_cache` module does not actually cache the CRL contents, so each handshake will trigger a new CRL lookup, which impacts the performance and reliability of TLS connections. In applications that require revocation checks as well as high throughput a custom CRL cache implementation will be needed.
 


### PR DESCRIPTION
I'm proposing this PR after coming across mds.fidoalliance.org:443's certificate which doesn't contain a CRL. It recently switched to OCSP as far as I can see:

```
-----BEGIN CERTIFICATE-----
MIIDuzCCA0GgAwIBAgISAwks8G62Fql4kngFvP910sQYMAoGCCqGSM49BAMDMDIx
CzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQDEwJF
MTAeFw0yNDAxMTgwNTQ3NTdaFw0yNDA0MTcwNTQ3NTZaMBsxGTAXBgNVBAMTEGZp
ZG9hbGxpYW5jZS5vcmcwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAR1GfbxKIwe
8eIwMybd/7btDOAt6cF7OT11y4F6UBI/CYrGW1tGH+bdttruID2OhDEyJJoHC0Ld
M6mzSqXfHbCZo4ICTDCCAkgwDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsG
AQUFBwMBBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRoJiwh7Sb4
/xBwZd49m9oB+yy9wDAfBgNVHSMEGDAWgBRa8+0r/DbCN3m5UjDqVG/PVcsurDBV
BggrBgEFBQcBAQRJMEcwIQYIKwYBBQUHMAGGFWh0dHA6Ly9lMS5vLmxlbmNyLm9y
ZzAiBggrBgEFBQcwAoYWaHR0cDovL2UxLmkubGVuY3Iub3JnLzBWBgNVHREETzBN
ghIqLmZpZG9hbGxpYW5jZS5vcmeCJSoub25kZW1hbmQuY2VydGluZnJhLmZpZG9h
bGxpYW5jZS5vcmeCEGZpZG9hbGxpYW5jZS5vcmcwEwYDVR0gBAwwCjAIBgZngQwB
AgEwggEDBgorBgEEAdZ5AgQCBIH0BIHxAO8AdgBIsONr2qZHNA/lagL6nTDrHFIB
y1bdLIHZu7+rOdiEcwAAAY0bU5GGAAAEAwBHMEUCIQCjtg1hnkODtl6vcwScOuya
tEZitciTsikLl7Py+CRRmwIgR9/vueh4CSVOpKuUYQQYxZM3KGeM4aHz/W87sJt7
EHIAdQA7U3d1Pi25gE6LMFsG/kA7Z9hPw/THvQANLXJv4frUFwAAAY0bU5GrAAAE
AwBGMEQCIG0UvM7lVlEpTm1iZBbQBB6Y6yaqbpheQEKb/mQvDqT5AiAJzkKs772d
UhS0e1bxgxDFLXomR0LIzLaI6oUVPrSwuzAKBggqhkjOPQQDAwNoADBlAjEA7/yf
67NFbHHc6WRX6jmCuAwm1thw/DqSaoo3EeVoowRNGEjPRWqT4IXO2Z2Qhb+OAjA6
IB56di6XAtnld6EJaptCeG9bYuv9xI/HEIUF71l970yDCPJ1fpJEPmoF6YO7Xwo=
-----END CERTIFICATE-----
```

Using `true` for `crl_check`, validation fails. We don't have OCSP implemented yet in BEAM, but still I think we need to let these chain validate. What do you think?

The issue with the current recommendation is that a configured HTTP client can fail when certificate is updated to OCSP-only (which recently happened with `wax`).