### PR TITLE
Add Vulnerability Disclosure Guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ We welcome feedback and suggestions, especially to public drafts: please open an
 
 * [Secure Coding and Deployment Hardening Guidelines](secure_coding_and_deployment_hardening) (draft)
 * [Web Application Security Best Practices for BEAM languages](web_app_security_best_practices_beam) (draft)
+* [Security Vulnerability Disclosure](security_vulnerability_disclosure) (draft)
 
 # Specifications
 

--- a/docs/security_vulnerability_disclosure/checklist.md
+++ b/docs/security_vulnerability_disclosure/checklist.md
@@ -1,0 +1,63 @@
+---
+title: Checklist
+layout: page
+previous:
+  url: github_disclosure
+  title: GitHub Disclosure
+next:
+  url: resources
+  title: Resources
+---
+
+Handling security vulnerabilities in a timely and responsible manner is crucial
+for maintaining the integrity and security of your project. Use the following
+checklist to ensure that you address vulnerabilities effectively:
+
+1. **Publish Fix**:
+   - Develop and implement a fix for the vulnerability in your project's codebase.
+   - Ensure that the fix addresses the root cause of the vulnerability and does
+     not introduce new issues or regressions.
+
+2. **Attribute Reporter**:
+   - Acknowledge and attribute the reporter who identified and reported the
+     vulnerability. Recognizing the efforts of security researchers encourages
+     responsible disclosure and fosters a collaborative security culture.
+
+3. **Disclose & Request CVE**:
+   - Document the vulnerability, including its impact, affected versions, and
+     mitigations, in a security advisory on GitHub or your project's website.
+   - Request a Common Vulnerabilities and Exposures (CVE) identifier for the
+     vulnerability through GitHub's security advisory interface or other
+     appropriate channels.
+   - Provide clear and comprehensive information to users and stakeholders to
+     help them understand the nature and severity of the vulnerability.
+   - Check that the disclosure is visible in the
+     [GitHub Advisory database](https://github.com/advisories?query=type%3Areviewed+ecosystem%3Aerlang).
+     If it is not, search for your CVE and make sure that the affected package &
+     versions are properly declared.
+
+1. **Retire Hex Package**:
+   - If the vulnerability affects a package published on Hex.pm, consider
+     retiring the package to prevent further installations.
+   - Update the retirement status of the affected package on Hex to notify users
+     of the vulnerability and encourage them to transition to safer alternatives.
+
+2. **Communicate Fixes and Mitigations**:
+   - Publish the fix and mitigations, along with clear instructions for users to
+     update their installations or implement workarounds.
+   - Notify users of the availability of the fix through release notes, blog
+     posts, social media, or other communication channels.
+   - Provide guidance on best practices for securing their systems and
+     mitigating the impact of the vulnerability until they can apply the fix.
+
+3. **Monitor and Follow Up**:
+   - Monitor the effectiveness of the fix and any related mitigations to ensure
+     that they adequately address the vulnerability.
+   - Follow up with users and stakeholders to verify that they have applied the
+     fix and are protected against the vulnerability.
+   - Stay vigilant for any signs of exploitation or recurrence of the
+     vulnerability and be prepared to take further action if necessary.
+
+By following this checklist, you can ensure that vulnerabilities in your project
+are addressed promptly and responsibly, minimizing the risk to your users and
+maintaining trust in your project's security practices.

--- a/docs/security_vulnerability_disclosure/github_disclosure.md
+++ b/docs/security_vulnerability_disclosure/github_disclosure.md
@@ -1,0 +1,54 @@
+---
+title: GitHub Disclosure
+layout: page
+previous:
+  url: process
+  title: Process
+next:
+  url: checklist
+  title: Checklist
+---
+
+GitHub provides several features to facilitate the security disclosure process
+for open-source projects, ensuring timely and effective resolution of
+vulnerabilities. Below are key features of GitHub's security disclosure process:
+
+1. [**Private Reporting**](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability):
+   - GitHub offers a secure and private channel for reporting security
+     vulnerabilities directly to project maintainers. Users can submit
+     vulnerability reports confidentially, allowing maintainers to assess and
+     address the issues before they are publicly disclosed.
+   - Private reporting helps prevent premature disclosure of vulnerabilities,
+     giving maintainers the opportunity to develop and deploy fixes before
+     potential attackers exploit the vulnerabilities.
+
+2. [**Publishing the Vulnerability**](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/managing-privately-reported-security-vulnerabilities):
+   - Once a vulnerability has been identified, GitHub provides tools for
+     publishing detailed descriptions of the vulnerability, including its
+     impact, affected versions of the library or package, and relevant Common
+     Weakness Enumeration (CWE) identifiers.
+   - Maintainers can document the vulnerability on GitHub, providing clear and
+     comprehensive information for users and stakeholders. This documentation
+     helps users understand the nature and severity of the vulnerability and
+     take appropriate action to protect their systems.
+
+3. **CVE Requests**:
+   - GitHub supports the request and assignment of Common Vulnerabilities and
+     Exposures (CVE) identifiers for reported vulnerabilities. Maintainers can
+     request CVE identifiers directly through GitHub's security advisory
+     interface.
+   - GitHub streamlines the process of requesting CVE identifiers, reducing the
+     administrative burden on maintainers and ensuring that vulnerabilities are
+     properly cataloged and tracked in the CVE database.
+   - By assigning CVE identifiers, maintainers contribute to the standardization
+     and visibility of vulnerability information, enabling better coordination
+     and collaboration within the security community.
+
+GitHub's security disclosure process features empower maintainers to effectively
+manage security vulnerabilities in their projects while maintaining transparency
+and accountability. From private reporting channels to streamlined CVE requests,
+GitHub provides a comprehensive toolkit for handling security incidents and
+safeguarding the integrity of open-source software projects.
+
+You can see an example for this process in a disclosure for one of
+[ErlEFs libraries](https://github.com/erlef/oidcc/security/advisories/GHSA-mj35-2rgf-cv8p).

--- a/docs/security_vulnerability_disclosure/index.md
+++ b/docs/security_vulnerability_disclosure/index.md
@@ -1,0 +1,62 @@
+---
+title: Guidelines for Security Vulnerability Disclosure for Library Authors on the BEAM
+layout: page
+next:
+  url: target_audience
+  title: Target Audience
+---
+
+In the dynamic and rapidly evolving landscape of software development, ensuring
+the security of libraries and frameworks is paramount. The BEAM ecosystem, which
+includes Erlang, Elixir, Gleam and LFE among others, is renowned for its
+robustness, scalability, and fault-tolerance. However, like any other technology
+stack, it is not immune to security vulnerabilities. As library authors play a
+crucial role in maintaining the integrity and security of the BEAM ecosystem, it
+becomes imperative to establish clear guidelines for disclosing and addressing
+security vulnerabilities.
+
+This document serves as a comprehensive guide for library authors within the
+BEAM community, outlining the processes and best practices for handling security
+vulnerabilities effectively. By following these guidelines, library authors can
+contribute to enhancing the overall security posture of the BEAM ecosystem while
+fostering transparency and collaboration among developers, security researchers,
+and end-users.
+
+The objectives of this document are threefold:
+
+* **Clarifying Responsibilities:** Library authors need to understand their
+  responsibilities concerning the discovery, disclosure, and mitigation of
+  security vulnerabilities in their codebases. Clear delineation of roles and
+  expectations ensures a coordinated and timely response to security incidents.
+* **Establishing Reporting Mechanisms:** Effective communication channels are
+  vital for reporting security vulnerabilities. This document outlines the
+  preferred methods and contacts for reporting security issues, facilitating
+  prompt assessment and remediation.
+* **Implementing Remediation Procedures:** Upon receiving reports of security
+  vulnerabilities, library authors must follow structured procedures for
+  triaging, validating, and addressing the reported issues. Timely patches or
+  updates should be developed and communicated to users to mitigate potential
+  risks.
+
+By adhering to these guidelines, library authors can demonstrate their
+commitment to maintaining a secure and resilient BEAM ecosystem, earning the
+trust and confidence of their users and stakeholders. Together, we can create a
+safer environment for building and deploying applications, safeguarding critical
+systems and sensitive data against emerging threats.
+
+## Contents
+
+* [Target Audience](target_audience)
+* [Vulnerability Definition](vulnerability_definition)
+* [User Tooling](user_tooling)
+* [Process](process)
+* [GitHub Disclosure](github_disclosure)
+
+The ErlEF Security Working Group ([security@erlef.org](mailto:security@erlef.org))
+offers to connect individuals with experts who can assist in coordinating and
+disclosing vulnerabilities within the BEAM ecosystem. While the WG does not
+handle direct disclosures, it helps to facilitate communication with experienced
+professionals in security vulnerability management.
+
+To report mistakes or suggest additional content, please open an issue or create
+a pull request in the [GitHub repository]({{site.github.repository_url}}).

--- a/docs/security_vulnerability_disclosure/process.md
+++ b/docs/security_vulnerability_disclosure/process.md
@@ -1,0 +1,62 @@
+---
+title: Process
+layout: page
+previous:
+  url: user_tooling
+  title: User Tooling
+next:
+  url: github_disclosure
+  title: GitHub Disclosure
+---
+
+**Essential Components of a Security Disclosure Process**
+
+A robust security disclosure process is essential for effectively handling
+security vulnerabilities in library projects within the BEAM ecosystem. While
+this document provides an overview of key components, further details and best
+practices can be found in resources such as the OpenSSF guide,
+["Guide to implementing a coordinated vulnerability disclosure process for open source projects."](https://github.com/ossf/oss-vulnerability-guide/blob/main/maintainer-guide.md)
+Below are the most essential parts of a security disclosure process:
+
+1. **Publish your vulnerability management process**:
+   - The first step is to create and publish a clear and comprehensive document
+     outlining the security disclosure process for the library project. This
+     document should detail the steps for reporting vulnerabilities, the
+     expected timeline for response and resolution, and the communication
+     channels to be used.
+
+1. **Accepting User Reports**:
+   - Establish mechanisms for users to report security vulnerabilities securely.
+     Provide clear instructions on how users can submit reports, including
+     contact information, or dedicated reporting channels such as email addresses
+     or bug tracking systems.
+
+2. **Communicating the State of the Disclosure Back to the Reporter**:
+   - Upon receiving a vulnerability report, acknowledge the receipt of the
+     report and provide an initial assessment of its validity and severity.
+     Keep the reporter informed about the progress of the disclosure process,
+     including any investigations, mitigations, or fixes implemented.
+
+3. **Implementing & Publishing a Fix**:
+   - Once a vulnerability is confirmed, work promptly to develop and implement a
+     fix. Ensure that the fix addresses the root cause of the vulnerability and
+     does not introduce regressions or new issues. Once the fix is ready,
+     publish it along with clear instructions for users to update their
+     installations.
+
+4. **Disclosing the Vulnerability (CVE & Hex)**:
+   - After the fix has been implemented and distributed to users, disclose the
+     vulnerability publicly. Assign a Common Vulnerabilities and Exposures (CVE)
+     identifier to the vulnerability, if applicable, to facilitate tracking and
+     referencing. Additionally, update the retirement status (
+     [Elixir](https://hexdocs.pm/hex/Mix.Tasks.Hex.Retire.html) /
+     [Erlang](https://rebar3.org/docs/package_management/#retiring-packages))
+     of the affected package on Hex, if necessary, to alert users to the presence
+     of the vulnerability.
+
+It's important to note that while these are the essential components of a
+security disclosure process, each project may have unique considerations and
+requirements. Regular review and refinement of the process are recommended to
+adapt to evolving security landscape and community feedback. For further
+guidance and detailed best practices, refer to the
+[OpenSSF guide on coordinated vulnerability disclosure processes for open source projects](https://github.com/ossf/oss-vulnerability-guide/blob/main/maintainer-guide.md).

--- a/docs/security_vulnerability_disclosure/resources.md
+++ b/docs/security_vulnerability_disclosure/resources.md
@@ -1,0 +1,25 @@
+---
+title: Resources
+layout: page
+previous:
+  url: checklist
+  title: Checklist
+next:
+  url: index
+  title: Contents
+---
+
+## Guides
+
+* [OpenSSF Guide to implementing a coordinated vulnerability disclosure process for open source projects](https://github.com/ossf/oss-vulnerability-guide/blob/main/maintainer-guide.md)
+* [GitHub Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+* [GitHub Managing privately reported security vulnerabilities](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/managing-privately-reported-security-vulnerabilities)
+* [Publishing a CVE](https://www.cve.org/ReportRequest/ReportRequestForNonCNAs)
+* [Hex Package Retire](https://hexdocs.pm/hex/Mix.Tasks.Hex.Retire.html)
+* [Rebar Package Retire](https://rebar3.org/docs/package_management/#retiring-packages)
+
+## Vulnerability Database
+
+* [GitHub Hex Advisories](https://github.com/advisories?query=type%3Areviewed+ecosystem%3Aerlang)
+* [CVE Details](https://www.cve.org/)
+* [OSV Database](https://osv.dev/list)

--- a/docs/security_vulnerability_disclosure/target_audience.md
+++ b/docs/security_vulnerability_disclosure/target_audience.md
@@ -1,0 +1,40 @@
+---
+title: Target Audience
+layout: page
+previous:
+  url: index
+  title: Contents
+next:
+  url: vulnerability_definition
+  title: Vulnerability Definition
+---
+
+## Who is this document for?
+
+
+The target audience for this document primarily comprises library authors within
+the BEAM ecosystem, encompassing developers who design, maintain, and distribute
+libraries and frameworks for use by other developers. Within this broad
+audience, several key segments can be identified, including:
+
+* **Open Source Library Maintainers & Contributors:** This group consists of
+  individual developers and team members who create, maintain, and contribute to
+  open-source libraries and frameworks within the BEAM ecosystem. It includes
+  those responsible for the full lifecycle of library development and
+  maintenance, from design to support.
+* **Commercial Library Providers:** These are organizations and individuals who
+  develop and distribute commercial libraries or frameworks for development on
+  the BEAM. They must adhere to stringent security practices to ensure customer
+  trust and compliance.
+* **Security-Conscious Developers:** These developers, although not directly
+  involved in library maintenance, rely on third-party libraries and benefit
+  from understanding the security vulnerability disclosure processes. This
+  knowledge helps them assess and mitigate risks effectively.
+
+For maintainers of popular libraries, in particular, the document addresses
+their unique position within the BEAM ecosystem. Given the extensive usage and
+potential impact of their libraries, maintainers of popular projects must be
+especially diligent in handling security vulnerabilities promptly and
+transparently. Their actions can significantly influence the overall security
+posture of the BEAM community, making them a key focus of the guidelines
+outlined in the document.

--- a/docs/security_vulnerability_disclosure/user_tooling.md
+++ b/docs/security_vulnerability_disclosure/user_tooling.md
@@ -1,0 +1,78 @@
+---
+title: User Tooling
+layout: page
+previous:
+  url: vulnerability_definition
+  title: Vulnerability Definition
+next:
+  url: process
+  title: Process
+---
+
+Users of BEAM languages, such as Erlang and Elixir, have access to several tools
+to help them identify if their dependencies are vulnerable to security issues.
+These tools enable users to proactively monitor their dependencies for known
+vulnerabilities, ensuring the integrity and security of their applications.
+Here's an overview of the tooling available:
+
+1. [**Hex Audit (`mix hex.audit`)**](https://hexdocs.pm/hex/Mix.Tasks.Hex.Audit.html):
+   - Hex.pm, the package manager for the ecosystem, can retire packages for
+     security reasons. The `mix hex.audit` command allows users to check if any
+     of their dependencies have been retired due to security concerns.
+   - This tool can be integrated into continuous integration (CI) pipelines to
+     automatically check dependencies for retirement status, providing early
+     warning of potential security risks.
+
+2. [**MixAudit (`mix deps.audit`)**](https://github.com/mirego/mix_audit):
+   - MixAudit is a tool that checks if any dependencies in an Elixir project are
+     part of disclosed vulnerabilities. It leverages the curated vulnerability
+     reports in the GitHub Vulnerability Database.
+   - By running `mix deps.audit`, users can quickly identify if any of their
+     project dependencies have known vulnerabilities, allowing them to take
+     appropriate action to mitigate risks.
+   - Similar to `mix hex.audit`, MixAudit can be incorporated into CI workflows
+     to automate vulnerability checks and ensure continuous security monitoring.
+
+3. **Commercial Tools (e.g., [Paraxial.io](https://paraxial.io/))**:
+   - Commercial solutions like Paraxial.io offer advanced features for
+     monitoring dependency vulnerabilities at runtime.
+   - These tools provide real-time reporting and alerts when a dependency
+     becomes vulnerable, allowing users to react promptly to emerging security
+     threats.
+   - Leveraging curated vulnerability reports from sources like the GitHub
+     Vulnerability Database, these tools offer comprehensive coverage and
+     accuracy in identifying security issues.
+
+By utilizing these tools, users of BEAM languages can stay vigilant against
+potential security vulnerabilities in their dependencies. Whether through
+retirement status checks, static analysis of disclosed vulnerabilities, or
+real-time monitoring at runtime, these tools empower developers to make informed
+decisions and take proactive measures to secure their applications. Integrating
+these tools into CI pipelines ensures that security checks are performed
+consistently and automatically, reducing the risk of exposure to known
+vulnerabilities throughout the development lifecycle.
+
+The retirement of packages in Hex and the proper disclosure of vulnerabilities
+in GitHub are essential for users of dependency vulnerability monitoring tools
+to effectively identify and mitigate security risks. When a package is retired
+in Hex due to security concerns, it signifies that the package is no longer
+considered safe for use, and users should transition away from it to maintain
+the security of their applications. Tools like `mix hex.audit` rely on the
+retirement status provided by Hex to flag dependencies that may pose security
+risks. Without accurate retirement information, users may unknowingly continue
+to use deprecated or vulnerable packages, leaving their applications susceptible
+to exploitation.
+
+Similarly, the proper disclosure of vulnerabilities in the GitHub Vulnerability
+Database is crucial for tools like MixAudit to identify known security issues in
+project dependencies. When vulnerabilities are disclosed and documented in the
+GitHub database, tools can cross-reference dependencies against these reports to
+determine if any components are affected. This ensures that users are promptly
+notified of vulnerabilities in their dependencies, enabling them to take
+immediate action to update or replace vulnerable packages. However, without
+comprehensive and up-to-date vulnerability disclosures, users may miss critical
+security alerts, leaving their applications exposed to potential attacks.
+Therefore, transparent and timely disclosure of vulnerabilities in publicly
+accessible databases is fundamental for maintaining the effectiveness of
+dependency vulnerability monitoring tools and safeguarding the integrity of BEAM
+language applications.

--- a/docs/security_vulnerability_disclosure/vulnerability_definition.md
+++ b/docs/security_vulnerability_disclosure/vulnerability_definition.md
@@ -1,0 +1,74 @@
+---
+title: Vulnerability Definition
+layout: page
+previous:
+  url: target_audience
+  title: Target Audience
+next:
+  url: user_tooling
+  title: User Tooling
+---
+
+Determining whether an issue qualifies as a security vulnerability requiring
+special handling or if it's merely a bug involves a nuanced evaluation process.
+Here's how a library maintainer can make this determination:
+
+1. **Understanding Security Vulnerabilities**: The maintainer should have a
+   clear understanding of what constitutes a security vulnerability. Common
+   examples include authentication bypass, injection attacks, sensitive data
+   exposure, and denial-of-service vulnerabilities. Familiarity with common
+   security issues helps in identifying potential vulnerabilities more
+   accurately.
+
+2. **Assessing Impact**: The maintainer should assess the potential impact of
+   the reported issue on the library's users and systems. Questions to consider
+   include:
+   - Could this issue lead to unauthorized access to sensitive data?
+   - Does it have the potential to compromise system integrity or availability?
+   - Can it be exploited to execute arbitrary code or perform actions beyond the
+     user's privileges?
+
+1. **Reviewing Context and Scope**: Understanding the context in which the issue
+   occurs and its scope is crucial. The maintainer should consider factors such
+   as:
+   - Whether the issue affects a critical component of the library or its core
+     functionality.
+   - If the issue has broader implications beyond the immediate codebase, such
+     as affecting dependent applications or integrations.
+   - Whether the issue is specific to certain configurations, environments, or
+     usage patterns.
+
+1. **Examining Attack Vectors**: Evaluating the potential attack vectors
+   associated with the reported issue provides insight into its severity.
+   Maintainers should consider:
+   - How easily an attacker can exploit the issue, including prerequisites and
+     required access levels.
+   - Whether the issue can be exploited remotely or requires local access.
+   - If exploitation requires user interaction or can be automated.
+
+2. **Considering Mitigation Complexity**: Assessing the complexity of mitigating
+   the issue helps determine the level of urgency and special handling required.
+   Factors to consider include:
+   - Whether a straightforward fix or workaround is available.
+   - If addressing the issue involves significant code changes or architectural
+     modifications.
+   - Whether mitigating the issue requires coordination with upstream
+     dependencies or third-party components.
+
+3. **Consulting Security Experts**: In complex cases or when uncertain, seeking
+   advice from security experts or the broader community can provide valuable
+   insights. Security professionals can offer guidance on threat modeling, risk
+   assessment, and appropriate mitigation strategies.
+
+   The ErlEF Security Working Group ([security@erlef.org](mailto:security@erlef.org))
+   offers to connect individuals with experts who can assist in coordinating and
+   disclosing vulnerabilities within the BEAM ecosystem. While the WG does not
+   handle direct disclosures, it helps to facilitate communication with experienced
+   professionals in security vulnerability management.
+
+By carefully considering these factors, a library maintainer can make informed
+decisions about whether a reported issue constitutes a security vulnerability
+that necessitates special handling or is a benign bug requiring routine bug-fix
+procedures. This discernment ensures that critical security issues receive the
+attention and prioritization they deserve, ultimately enhancing the overall
+security posture of the library and its users.


### PR DESCRIPTION
Add a guide on Vulnerability Disclosure.

The current state relies heavily on ChatGPT, but should outline the contents that I wanted to cover.

If we merge this, I would ask Hex.pm to link to this guide on their website as well.